### PR TITLE
Add description templates to errors

### DIFF
--- a/lib/ex_json_schema/schema.ex
+++ b/lib/ex_json_schema/schema.ex
@@ -50,12 +50,18 @@ defmodule NExJsonSchema.Schema do
       case NExJsonSchema.Validator.validate(resolve(Draft4.schema()), schema) do
         {:error, errors} ->
           raise InvalidSchemaError,
-            message: "schema did not pass validation against its meta-schema: #{inspect(errors)}"
+            message: "schema did not pass validation against its meta-schema:#{format_error_messages(errors)}"
 
         _ ->
           nil
       end
     end
+  end
+
+  defp format_error_messages([]), do: ""
+
+  defp format_error_messages([{%{description: description}, path} | errors]) do
+    "\n* #{description} (at #{path})" <> format_error_messages(errors)
   end
 
   defp supported_schema_version?(version) do

--- a/lib/ex_json_schema/validator/dependencies.ex
+++ b/lib/ex_json_schema/validator/dependencies.ex
@@ -26,11 +26,12 @@ defmodule NExJsonSchema.Validator.Dependencies do
 
         false ->
           [
-            {%{
-               description: "property #{property} depends on #{dependency} to be present but it was not",
-               rule: :dependency,
-               params: [dependency]
-             }, [property]}
+            {Validator.format_error(
+               :dependency,
+               "property %{property} depends on %{dependency} to be present but it was not",
+               property: property,
+               dependency: dependency
+             ), [property]}
           ]
       end
     end)

--- a/lib/ex_json_schema/validator/format.ex
+++ b/lib/ex_json_schema/validator/format.ex
@@ -19,21 +19,22 @@ defmodule NExJsonSchema.Validator.Format do
   defp do_validate("date-time", data) do
     validate_with_regex_result =
       validate_with_regex(data, @date_time_regex, fn data ->
-        %{
-          description: "expected #{inspect(data)} to be a valid ISO 8601 date-time",
-          rule: :datetime,
-          params: [inspect(@date_time_regex)]
-        }
+        Validator.format_error(
+          :datetime,
+          "expected %{actual} to be a valid ISO 8601 date-time",
+          pattern: Regex.source(@date_time_regex),
+          actual: inspect(data)
+        )
       end)
 
     case validate_with_regex_result do
       [] ->
         validate_date_existence("date-time", data, fn data ->
-          %{
-            description: "expected #{inspect(data)} to be an existing date-time",
-            rule: :datetime,
-            params: []
-          }
+          Validator.format_error(
+            :datetime,
+            "expected %{actual} to be an existing date-time",
+            actual: inspect(data)
+          )
         end)
 
       error ->
@@ -44,21 +45,22 @@ defmodule NExJsonSchema.Validator.Format do
   defp do_validate("date", data) do
     validate_with_regex_result =
       validate_with_regex(data, @date_regex, fn data ->
-        %{
-          description: "expected #{inspect(data)} to be a valid ISO 8601 date",
-          rule: :date,
-          params: [inspect(@date_regex)]
-        }
+        Validator.format_error(
+          :date,
+          "expected %{actual} to be a valid ISO 8601 date",
+          pattern: Regex.source(@date_regex),
+          actual: inspect(data)
+        )
       end)
 
     case validate_with_regex_result do
       [] ->
         validate_date_existence("date", data, fn data ->
-          %{
-            description: "expected #{inspect(data)} to be an existing date",
-            rule: :date,
-            params: []
-          }
+          Validator.format_error(
+            :date,
+            "expected %{actual} to be an existing date",
+            actual: inspect(data)
+          )
         end)
 
       error ->
@@ -68,41 +70,45 @@ defmodule NExJsonSchema.Validator.Format do
 
   defp do_validate("email", data) do
     validate_with_regex(data, @email_regex, fn data ->
-      %{
-        description: "expected #{inspect(data)} to be an email address",
-        rule: :email,
-        params: [inspect(@email_regex)]
-      }
+      Validator.format_error(
+        :email,
+        "expected %{actual} to be an email address",
+        pattern: Regex.source(@email_regex),
+        actual: inspect(data)
+      )
     end)
   end
 
   defp do_validate("hostname", data) do
     validate_with_regex(data, @hostname_regex, fn data ->
-      %{
-        description: "expected #{inspect(data)} to be a host name",
-        rule: :format,
-        params: [inspect(@hostname_regex)]
-      }
+      Validator.format_error(
+        :format,
+        "expected %{actual} to be a host name",
+        pattern: Regex.source(@hostname_regex),
+        actual: inspect(data)
+      )
     end)
   end
 
   defp do_validate("ipv4", data) do
     validate_with_regex(data, @ipv4_regex, fn data ->
-      %{
-        description: "expected #{inspect(data)} to be an IPv4 address",
-        rule: :format,
-        params: [inspect(@ipv4_regex)]
-      }
+      Validator.format_error(
+        :format,
+        "expected %{actual} to be an IPv4 address",
+        pattern: Regex.source(@ipv4_regex),
+        actual: inspect(data)
+      )
     end)
   end
 
   defp do_validate("ipv6", data) do
     validate_with_regex(data, @ipv6_regex, fn data ->
-      %{
-        description: "expected #{inspect(data)} to be an IPv6 address",
-        rule: :format,
-        params: [inspect(@ipv6_regex)]
-      }
+      Validator.format_error(
+        :format,
+        "expected %{actual} to be an IPv6 address",
+        pattern: Regex.source(@ipv6_regex),
+        actual: inspect(data)
+      )
     end)
   end
 

--- a/lib/ex_json_schema/validator/items.ex
+++ b/lib/ex_json_schema/validator/items.ex
@@ -27,11 +27,10 @@ defmodule NExJsonSchema.Validator.Items do
 
   defp validate_item(_, nil, _, index) do
     [
-      {%{
-         description: "schema does not allow additional items",
-         rule: :schema,
-         params: []
-       }, ["[#{index}]"]}
+      {Validator.format_error(
+         :schema,
+         "schema does not allow additional items"
+       ), ["[#{index}]"]}
     ]
   end
 

--- a/lib/ex_json_schema/validator/properties.ex
+++ b/lib/ex_json_schema/validator/properties.ex
@@ -49,11 +49,11 @@ defmodule NExJsonSchema.Validator.Properties do
 
   defp validate_additional_properties(_, false, properties) when map_size(properties) > 0 do
     Enum.map(properties, fn {name, _} ->
-      {%{
-         description: "schema does not allow additional properties",
-         rule: :schema,
-         params: properties
-       }, [name]}
+      {Validator.format_error(
+         :schema,
+         "schema does not allow additional properties",
+         properties: properties
+       ), [name]}
     end)
   end
 

--- a/lib/ex_json_schema/validator/type.ex
+++ b/lib/ex_json_schema/validator/type.ex
@@ -9,11 +9,12 @@ defmodule NExJsonSchema.Validator.Type do
 
       false ->
         [
-          {%{
-             description: "type mismatch. Expected #{type |> type_name} but got #{data |> data_type |> type_name}",
-             rule: :cast,
-             params: [type]
-           }, []}
+          {Validator.format_error(
+             :cast,
+             "type mismatch. Expected %{expected} but got %{actual}",
+             expected: type,
+             actual: data_type(data)
+           ), []}
         ]
     end
   end

--- a/test/ex_json_schema/schema_test.exs
+++ b/test/ex_json_schema/schema_test.exs
@@ -29,7 +29,7 @@ defmodule NExJsonSchema.SchemaTest do
     schema = %{"properties" => "foo"}
 
     assert_raise NExJsonSchema.Schema.InvalidSchemaError,
-                 ~s(schema did not pass validation against its meta-schema: [{%{description: \"type mismatch. Expected Object but got String\", params: [\"object\"], rule: :cast}, \"$.properties\"}]),
+                 "schema did not pass validation against its meta-schema:\n* type mismatch. Expected object but got string (at $.properties)",
                  fn -> resolve(schema) end
   end
 

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -10,7 +10,12 @@ defmodule NExJsonSchema.ValidatorTest do
 
   test "required properties are not validated when the data is not a map" do
     assert_validation_errors(%{"required" => ["foo"], "type" => "object"}, "foo", [
-      {%{description: "type mismatch. Expected Object but got String", params: ["object"], rule: :cast}, "$"}
+      {%{
+         raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+         description: "type mismatch. Expected object but got string",
+         params: [expected: "object", actual: "string"],
+         rule: :cast
+       }, "$"}
     ])
   end
 
@@ -18,7 +23,14 @@ defmodule NExJsonSchema.ValidatorTest do
     assert_validation_errors(
       %{"foo" => %{"type" => "object"}, "properties" => %{"bar" => %{"$ref" => "#/foo"}}},
       %{"bar" => "baz"},
-      [{%{description: "type mismatch. Expected Object but got String", params: ["object"], rule: :cast}, "$.bar"}]
+      [
+        {%{
+           raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+           description: "type mismatch. Expected object but got string",
+           params: [expected: "object", actual: "string"],
+           rule: :cast
+         }, "$.bar"}
+      ]
     )
   end
 
@@ -84,15 +96,22 @@ defmodule NExJsonSchema.ValidatorTest do
 
   test "validation errors with a remote reference within a remote reference" do
     assert_validation_errors(%{"$ref" => "http://localhost:8000/subschema.json#/foo"}, "foo", [
-      {%{description: "type mismatch. Expected Integer but got String", params: ["integer"], rule: :cast}, "$"}
+      {%{
+         raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+         description: "type mismatch. Expected integer but got string",
+         params: [expected: "integer", actual: "string"],
+         rule: :cast
+       }, "$"}
     ])
   end
 
   test "validation errors for not matching all of the schemata" do
     assert_validation_errors(%{"allOf" => [%{"type" => "number"}, %{"type" => "integer"}]}, "foo", [
       {%{
+         raw_description:
+           "expected all of the schemata to match, but the schemata at the following indexes did not: %{indexes}",
          description: "expected all of the schemata to match, but the schemata at the following indexes did not: 0, 1",
-         params: [],
+         params: [indexes: [0, 1]],
          rule: :schemata
        }, "$"}
     ])
@@ -100,16 +119,23 @@ defmodule NExJsonSchema.ValidatorTest do
 
   test "validation errors for not matching any of the schemata" do
     assert_validation_errors(%{"anyOf" => [%{"type" => "number"}, %{"type" => "integer"}]}, "foo", [
-      {%{description: "expected any of the schemata to match but none did", params: [], rule: :schemata}, "$"}
+      {%{
+         raw_description: "expected any of the schemata to match but none did",
+         description: "expected any of the schemata to match but none did",
+         params: [],
+         rule: :schemata
+       }, "$"}
     ])
   end
 
   test "validation errors for matching more than one of the schemata when exactly one should be matched" do
     assert_validation_errors(%{"oneOf" => [%{"type" => "number"}, %{"type" => "integer"}]}, 5, [
       {%{
+         raw_description:
+           "expected exactly one of the schemata to match, but the schemata at the following indexes did: %{indexes}",
          description:
            "expected exactly one of the schemata to match, but the schemata at the following indexes did: 0, 1",
-         params: [],
+         params: [indexes: [0, 1]],
          rule: :schemata
        }, "$"}
     ])
@@ -118,6 +144,7 @@ defmodule NExJsonSchema.ValidatorTest do
   test "validation errors for matching none of the schemata when exactly one should be matched" do
     assert_validation_errors(%{"oneOf" => [%{"type" => "number"}, %{"type" => "integer"}]}, "foo", [
       {%{
+         raw_description: "expected exactly one of the schemata to match, but none of them did",
          description: "expected exactly one of the schemata to match, but none of them did",
          params: [],
          rule: :schemata
@@ -127,15 +154,21 @@ defmodule NExJsonSchema.ValidatorTest do
 
   test "validation errors for matching a schema when it should not be matched" do
     assert_validation_errors(%{"not" => %{"type" => "object"}}, %{}, [
-      {%{description: "expected schema not to match but it did", params: [], rule: :schema}, "$"}
+      {%{
+         raw_description: "expected schema not to match but it did",
+         description: "expected schema not to match but it did",
+         params: [],
+         rule: :schema
+       }, "$"}
     ])
   end
 
   test "validation errors for a wrong type" do
     assert_validation_errors(%{"type" => ["integer", "number"]}, "foo", [
       {%{
-         description: "type mismatch. Expected Integer, Number but got String",
-         params: [["integer", "number"]],
+         raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+         description: "type mismatch. Expected integer, number but got string",
+         params: [expected: ["integer", "number"], actual: "string"],
          rule: :cast
        }, "$"}
     ])
@@ -150,10 +183,24 @@ defmodule NExJsonSchema.ValidatorTest do
       },
       %{"foo" => true, "bar" => true, "baz" => 1, "xyz" => false},
       [
-        {%{description: "type mismatch. Expected String but got Boolean", params: ["string"], rule: :cast}, "$.foo"},
-        {%{description: "type mismatch. Expected Boolean but got Integer", params: ["boolean"], rule: :cast}, "$.baz"},
-        {%{description: "schema does not allow additional properties", params: %{"xyz" => false}, rule: :schema},
-         "$.xyz"}
+        {%{
+           raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+           description: "type mismatch. Expected string but got boolean",
+           params: [expected: "string", actual: "boolean"],
+           rule: :cast
+         }, "$.foo"},
+        {%{
+           raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+           description: "type mismatch. Expected boolean but got integer",
+           params: [expected: "boolean", actual: "integer"],
+           rule: :cast
+         }, "$.baz"},
+        {%{
+           raw_description: "schema does not allow additional properties",
+           description: "schema does not allow additional properties",
+           params: [properties: %{"xyz" => false}],
+           rule: :schema
+         }, "$.xyz"}
       ]
     )
   end
@@ -162,33 +209,64 @@ defmodule NExJsonSchema.ValidatorTest do
     assert_validation_errors(
       %{"properties" => %{"foo" => %{"type" => "string"}}, "additionalProperties" => %{"type" => "boolean"}},
       %{"foo" => "bar", "bar" => "baz"},
-      [{%{description: "type mismatch. Expected Boolean but got String", params: ["boolean"], rule: :cast}, "$.bar"}]
+      [
+        {%{
+           raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+           description: "type mismatch. Expected boolean but got string",
+           params: [expected: "boolean", actual: "string"],
+           rule: :cast
+         }, "$.bar"}
+      ]
     )
   end
 
   test "validation errors for minimum properties" do
     assert_validation_errors(%{"minProperties" => 2}, %{"foo" => 1}, [
-      {%{description: "expected a minimum of 2 properties but got 1", params: %{min: 2}, rule: :length}, "$"}
+      {%{
+         raw_description: "expected a minimum of %{min} properties but got %{actual}",
+         description: "expected a minimum of 2 properties but got 1",
+         params: [min: 2, actual: 1],
+         rule: :length
+       }, "$"}
     ])
   end
 
   test "validation errors for maximum properties" do
     assert_validation_errors(%{"maxProperties" => 1}, %{"foo" => 1, "bar" => 2}, [
-      {%{description: "expected a maximum of 1 properties but got 2", params: %{max: 1}, rule: :length}, "$"}
+      {%{
+         raw_description: "expected a maximum of %{max} properties but got %{actual}",
+         description: "expected a maximum of 1 properties but got 2",
+         params: [max: 1, actual: 2],
+         rule: :length
+       }, "$"}
     ])
   end
 
   test "validation errors for missing required properties" do
     assert_validation_errors(%{"required" => ["foo", "bar", "baz"]}, %{"foo" => 1}, [
-      {%{description: "required property bar was not present", params: [], rule: :required}, "$.bar"},
-      {%{description: "required property baz was not present", params: [], rule: :required}, "$.baz"}
+      {%{
+         raw_description: "required property %{property} was not present",
+         description: "required property bar was not present",
+         params: [property: "bar"],
+         rule: :required
+       }, "$.bar"},
+      {%{
+         raw_description: "required property %{property} was not present",
+         description: "required property baz was not present",
+         params: [property: "baz"],
+         rule: :required
+       }, "$.baz"}
     ])
   end
 
   test "validation errors for dependent properties" do
     assert_validation_errors(%{"dependencies" => %{"foo" => ["bar", "baz"]}}, %{"foo" => 1, "bar" => 2}, [
-      {%{description: "property foo depends on baz to be present but it was not", params: ["baz"], rule: :dependency},
-       "$.foo"}
+      {%{
+         raw_description: "property %{property} depends on %{dependency} to be present but it was not",
+         description: "property foo depends on baz to be present but it was not",
+         params: [property: "foo", dependency: "baz"],
+         rule: :dependency
+       }, "$.foo"}
     ])
   end
 
@@ -196,14 +274,31 @@ defmodule NExJsonSchema.ValidatorTest do
     assert_validation_errors(
       %{"dependencies" => %{"foo" => %{"properties" => %{"bar" => %{"type" => "boolean"}}}}},
       %{"foo" => 1, "bar" => 2},
-      [{%{description: "type mismatch. Expected Boolean but got Integer", params: ["boolean"], rule: :cast}, "$.bar"}]
+      [
+        {%{
+           raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+           description: "type mismatch. Expected boolean but got integer",
+           params: [expected: "boolean", actual: "integer"],
+           rule: :cast
+         }, "$.bar"}
+      ]
     )
   end
 
   test "validation errors for invalid items" do
     assert_validation_errors(%{"items" => %{"type" => "string"}}, ["foo", "bar", 1, %{}], [
-      {%{description: "type mismatch. Expected String but got Integer", params: ["string"], rule: :cast}, "$.[2]"},
-      {%{description: "type mismatch. Expected String but got Object", params: ["string"], rule: :cast}, "$.[3]"}
+      {%{
+         raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+         description: "type mismatch. Expected string but got integer",
+         params: [expected: "string", actual: "integer"],
+         rule: :cast
+       }, "$.[2]"},
+      {%{
+         raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+         description: "type mismatch. Expected string but got object",
+         params: [expected: "string", actual: "object"],
+         rule: :cast
+       }, "$.[3]"}
     ])
   end
 
@@ -215,41 +310,86 @@ defmodule NExJsonSchema.ValidatorTest do
       },
       [%{}, 1, "foo", true, 2.2],
       [
-        {%{description: "type mismatch. Expected String but got Object", params: ["string"], rule: :cast}, "$.[0]"},
-        {%{description: "type mismatch. Expected Integer but got String", params: ["integer"], rule: :cast}, "$.[2]"},
-        {%{description: "type mismatch. Expected Boolean but got Number", params: ["boolean"], rule: :cast}, "$.[4]"}
+        {%{
+           raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+           description: "type mismatch. Expected string but got object",
+           params: [expected: "string", actual: "object"],
+           rule: :cast
+         }, "$.[0]"},
+        {%{
+           raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+           description: "type mismatch. Expected integer but got string",
+           params: [expected: "integer", actual: "string"],
+           rule: :cast
+         }, "$.[2]"},
+        {%{
+           raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+           description: "type mismatch. Expected boolean but got number",
+           params: [expected: "boolean", actual: "number"],
+           rule: :cast
+         }, "$.[4]"}
       ]
     )
   end
 
   test "validation errors for disallowed additional items" do
     assert_validation_errors(%{"items" => [%{"type" => "boolean"}], "additionalItems" => false}, [true, false, "foo"], [
-      {%{description: "schema does not allow additional items", params: [], rule: :schema}, "$.[1]"},
-      {%{description: "schema does not allow additional items", params: [], rule: :schema}, "$.[2]"}
+      {%{
+         raw_description: "schema does not allow additional items",
+         description: "schema does not allow additional items",
+         params: [],
+         rule: :schema
+       }, "$.[1]"},
+      {%{
+         raw_description: "schema does not allow additional items",
+         description: "schema does not allow additional items",
+         params: [],
+         rule: :schema
+       }, "$.[2]"}
     ])
   end
 
   test "validation errors for minimum items" do
     assert_validation_errors(%{"minItems" => 2}, ["foo"], [
-      {%{description: "expected a minimum of 2 items but got 1", params: %{min: 2}, rule: :length}, "$"}
+      {%{
+         raw_description: "expected a minimum of %{min} items but got %{actual}",
+         description: "expected a minimum of 2 items but got 1",
+         params: [min: 2, actual: 1],
+         rule: :length
+       }, "$"}
     ])
   end
 
   test "validation errors for maximum items" do
     assert_validation_errors(%{"maxItems" => 2}, ["foo", "bar", "baz"], [
-      {%{description: "expected a maximum of 2 items but got 3", params: %{max: 2}, rule: :length}, "$"}
+      {%{
+         raw_description: "expected a maximum of %{max} items but got %{actual}",
+         description: "expected a maximum of 2 items but got 3",
+         params: [max: 2, actual: 3],
+         rule: :length
+       }, "$"}
     ])
   end
 
   test "validation errors for non-unique items" do
     assert_validation_errors(%{"uniqueItems" => true}, [1, 2, 3, 3], [
-      {%{description: "expected items to be unique but they were not", params: [], rule: :unique}, "$"}
+      {%{
+         raw_description: "expected items to be unique but they were not",
+         description: "expected items to be unique but they were not",
+         params: [],
+         rule: :unique
+       }, "$"}
     ])
   end
 
   test "validation errors for value not allowed in enum" do
     assert_validation_errors(%{"enum" => ["foo", "bar"]}, %{"baz" => 1}, [
-      {%{description: "value is not allowed in enum", params: ["foo", "bar"], rule: :inclusion}, "$"}
+      {%{
+         raw_description: "value is not allowed in enum",
+         description: "value is not allowed in enum",
+         params: [values: ["foo", "bar"]],
+         rule: :inclusion
+       }, "$"}
     ])
   end
 
@@ -258,9 +398,18 @@ defmodule NExJsonSchema.ValidatorTest do
       %{"properties" => %{"foo" => %{"minimum" => 2}, "bar" => %{"minimum" => 2, "exclusiveMinimum" => true}}},
       %{"foo" => 1, "bar" => 2},
       [
-        {%{description: "expected the value to be > 2", params: %{greater_than: 2}, rule: :number}, "$.bar"},
-        {%{description: "expected the value to be >= 2", params: %{greater_than_or_equal_to: 2}, rule: :number},
-         "$.foo"}
+        {%{
+           raw_description: "expected the value to be > %{greater_than}",
+           description: "expected the value to be > 2",
+           params: [greater_than: 2],
+           rule: :number
+         }, "$.bar"},
+        {%{
+           raw_description: "expected the value to be >= %{greater_than_or_equal_to}",
+           description: "expected the value to be >= 2",
+           params: [greater_than_or_equal_to: 2],
+           rule: :number
+         }, "$.foo"}
       ]
     )
   end
@@ -270,33 +419,63 @@ defmodule NExJsonSchema.ValidatorTest do
       %{"properties" => %{"foo" => %{"maximum" => 2}, "bar" => %{"maximum" => 2, "exclusiveMaximum" => true}}},
       %{"foo" => 3, "bar" => 2},
       [
-        {%{description: "expected the value to be < 2", params: %{less_than: 2}, rule: :number}, "$.bar"},
-        {%{description: "expected the value to be <= 2", params: %{less_than_or_equal_to: 2}, rule: :number}, "$.foo"}
+        {%{
+           raw_description: "expected the value to be < %{less_than}",
+           description: "expected the value to be < 2",
+           params: [less_than: 2],
+           rule: :number
+         }, "$.bar"},
+        {%{
+           raw_description: "expected the value to be <= %{less_than_or_equal_to}",
+           description: "expected the value to be <= 2",
+           params: [less_than_or_equal_to: 2],
+           rule: :number
+         }, "$.foo"}
       ]
     )
   end
 
   test "validation errors for multiples of" do
     assert_validation_errors(%{"multipleOf" => 2}, 5, [
-      {%{description: "expected value to be a multiple of 2 but got 5", params: %{multiple_of: 2}, rule: :number}, "$"}
+      {%{
+         raw_description: "expected value to be a multiple of %{multiple_of} but got %{actual}",
+         description: "expected value to be a multiple of 2 but got 5",
+         params: [multiple_of: 2, actual: 5],
+         rule: :number
+       }, "$"}
     ])
   end
 
   test "validation errors for minimum length" do
     assert_validation_errors(%{"minLength" => 4}, "foo", [
-      {%{description: "expected value to have a minimum length of 4 but was 3", params: %{min: 4}, rule: :length}, "$"}
+      {%{
+         raw_description: "expected value to have a minimum length of %{min} but was %{actual}",
+         description: "expected value to have a minimum length of 4 but was 3",
+         params: [min: 4, actual: 3],
+         rule: :length
+       }, "$"}
     ])
   end
 
   test "validation errors for maximum length" do
     assert_validation_errors(%{"maxLength" => 2}, "foo", [
-      {%{description: "expected value to have a maximum length of 2 but was 3", params: %{max: 2}, rule: :length}, "$"}
+      {%{
+         raw_description: "expected value to have a maximum length of %{max} but was %{actual}",
+         description: "expected value to have a maximum length of 2 but was 3",
+         params: [max: 2, actual: 3],
+         rule: :length
+       }, "$"}
     ])
   end
 
   test "validation errors for pattern mismatch" do
     assert_validation_errors(%{"pattern" => "^b..$"}, "foo", [
-      {%{description: "string does not match pattern \"^b..$\"", params: ["^b..$"], rule: :format}, "$"}
+      {%{
+         raw_description: "string does not match pattern %{pattern}",
+         description: "string does not match pattern ^b..$",
+         params: [pattern: "^b..$"],
+         rule: :format
+       }, "$"}
     ])
   end
 
@@ -305,8 +484,12 @@ defmodule NExJsonSchema.ValidatorTest do
       %{"properties" => %{"foo" => %{"items" => %{"properties" => %{"bar" => %{"type" => "integer"}}}}}},
       %{"foo" => [%{"bar" => 1}, %{"bar" => "baz"}]},
       [
-        {%{description: "type mismatch. Expected Integer but got String", params: ["integer"], rule: :cast},
-         "$.foo.[1].bar"}
+        {%{
+           raw_description: "type mismatch. Expected %{expected} but got %{actual}",
+           description: "type mismatch. Expected integer but got string",
+           params: [expected: "integer", actual: "string"],
+           rule: :cast
+         }, "$.foo.[1].bar"}
       ]
     )
   end
@@ -318,9 +501,12 @@ defmodule NExJsonSchema.ValidatorTest do
   test "validation errors for date-time format" do
     assert_validation_errors(%{"format" => "date-time"}, "2012-12-12 12:12:12", [
       {%{
+         raw_description: "expected %{actual} to be a valid ISO 8601 date-time",
          description: "expected \"2012-12-12 12:12:12\" to be a valid ISO 8601 date-time",
          params: [
-           "~r/^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$/"
+           pattern:
+             "^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$",
+           actual: "\"2012-12-12 12:12:12\""
          ],
          rule: :datetime
        }, "$"}
@@ -330,9 +516,12 @@ defmodule NExJsonSchema.ValidatorTest do
   test "validation errors for date format" do
     assert_validation_errors(%{"format" => "date"}, "1988.12.12", [
       {%{
+         raw_description: "expected %{actual} to be a valid ISO 8601 date",
          description: "expected \"1988.12.12\" to be a valid ISO 8601 date",
          params: [
-           "~r/^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))?)?$/"
+           pattern:
+             "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))?)?$",
+           actual: "\"1988.12.12\""
          ],
          rule: :date
        }, "$"}
@@ -342,8 +531,9 @@ defmodule NExJsonSchema.ValidatorTest do
   test "validation errors for date-time existence" do
     assert_validation_errors(%{"format" => "date-time"}, "1942-02-29T12:12:12", [
       {%{
+         raw_description: "expected %{actual} to be an existing date-time",
          description: "expected \"1942-02-29T12:12:12\" to be an existing date-time",
-         params: [],
+         params: [actual: "\"1942-02-29T12:12:12\""],
          rule: :datetime
        }, "$"}
     ])
@@ -356,8 +546,9 @@ defmodule NExJsonSchema.ValidatorTest do
   test "validation errors for date existence" do
     assert_validation_errors(%{"format" => "date"}, "1942-02-29", [
       {%{
+         raw_description: "expected %{actual} to be an existing date",
          description: "expected \"1942-02-29\" to be an existing date",
-         params: [],
+         params: [actual: "\"1942-02-29\""],
          rule: :date
        }, "$"}
     ])
@@ -370,8 +561,12 @@ defmodule NExJsonSchema.ValidatorTest do
   test "validation errors for email format" do
     assert_validation_errors(%{"format" => "email"}, "foo@", [
       {%{
+         raw_description: "expected %{actual} to be an email address",
          description: "expected \"foo@\" to be an email address",
-         params: ["~r/^[\\w!#$%&'*+\\/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+\\/=?`{|}~^-]+)*@(?:[A-Z0-9-]+\\.)+[A-Z]{2,6}$/i"],
+         params: [
+           pattern: "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[A-Z0-9-]+\\.)+[A-Z]{2,6}$",
+           actual: "\"foo@\""
+         ],
          rule: :email
        }, "$"}
     ])
@@ -380,8 +575,12 @@ defmodule NExJsonSchema.ValidatorTest do
   test "validation errors for hostname format" do
     assert_validation_errors(%{"format" => "hostname"}, "foo-bar", [
       {%{
+         raw_description: "expected %{actual} to be a host name",
          description: "expected \"foo-bar\" to be a host name",
-         params: ["~r/^((?=[a-z0-9-]{1,63}\\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,63}$/i"],
+         params: [
+           pattern: "^((?=[a-z0-9-]{1,63}\\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,63}$",
+           actual: "\"foo-bar\""
+         ],
          rule: :format
        }, "$"}
     ])
@@ -390,8 +589,12 @@ defmodule NExJsonSchema.ValidatorTest do
   test "validation errors for ipv4 format" do
     assert_validation_errors(%{"format" => "ipv4"}, "12.12.12", [
       {%{
+         raw_description: "expected %{actual} to be an IPv4 address",
          description: "expected \"12.12.12\" to be an IPv4 address",
-         params: ["~r/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/"],
+         params: [
+           pattern: "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
+           actual: "\"12.12.12\""
+         ],
          rule: :format
        }, "$"}
     ])
@@ -400,9 +603,11 @@ defmodule NExJsonSchema.ValidatorTest do
   test "validation errors for ipv6 format" do
     assert_validation_errors(%{"format" => "ipv6"}, "12:12:12", [
       {%{
+         raw_description: "expected %{actual} to be an IPv6 address",
          description: "expected \"12:12:12\" to be an IPv6 address",
          params: [
-           "~r/^(?:(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}|(?=(?:[A-F0-9]{0,4}:){0,7}[A-F0-9]{0,4}$)(([0-9A-F]{1,4}:){1,7}|:)((:[0-9A-F]{1,4}){1,7}|:)|(?:[A-F0-9]{1,4}:){7}:|:(:[A-F0-9]{1,4}){7})$/i"
+           pattern: "^(?:(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}|(?=(?:[A-F0-9]{0,4}:){0,7}[A-F0-9]{0,4}$)(([0-9A-F]{1,4}:){1,7}|:)((:[0-9A-F]{1,4}){1,7}|:)|(?:[A-F0-9]{1,4}:){7}:|:(:[A-F0-9]{1,4}){7})$",
+           actual: "\"12:12:12\""
          ],
          rule: :format
        }, "$"}


### PR DESCRIPTION
This change adds description templates to errors, so that error messages able to be translated using internationalization tools. Error descriptions now derive from templates, due to this all parameters become keyword lists which keys match with template expressions.